### PR TITLE
Removed LDFLAGS from cc command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OBJS= crypto_scrypt-nosse.o sha256.o crypto_scrypt-hexconvert.o crypto-mcf.o mod
 
 
 library: $(OBJS)
-	$(CC)  $(LDFLAGS) -shared -Wl,-soname,libscrypt.so.0 -Wl,--version-script=libscrypt.version -o libscrypt.so.0 -lc -lm  $(OBJS)
+	$(CC) -shared -Wl,-soname,libscrypt.so.0 -Wl,--version-script=libscrypt.version -o libscrypt.so.0 -lc -lm  $(OBJS)
 	ar rcs libscrypt.a  $(OBJS)
 
 reference: library main.o


### PR DESCRIPTION
Putting LDFLAGS in the compiler line is unnecessary, it will get picked up via the environment. It is also not accepted by the clang C compiler.
