### PR TITLE
Fix libscrypt_mcf return value check in libscrypt_hash

### DIFF
--- a/crypto_scrypt-hash.c
+++ b/crypto_scrypt-hash.c
@@ -35,7 +35,7 @@ int libscrypt_hash(char *dst, char *passphrase, uint32_t N, uint8_t r, uint8_t p
 		return 0;
 
 	retval = libscrypt_mcf(N, r, p, saltbuf, outbuf, dst);
-	if(retval == -1)
+	if(!retval)
 		return 0;
 
 	return 1;


### PR DESCRIPTION
libscrypt_mcf returns 0 on failure, not -1

If you try to pass NULL as dst to libscrypt_hash you'll get 1 (success) as a return value, because it interprets the return value 0 from libscrypt_mcf wrong.

Better would be to unify all functions to use the same convention, but that would break API.
