### PR TITLE
Sanity check N > 1 in libscrypt_scrypt

### DIFF
--- a/crypto_scrypt-nosse.c
+++ b/crypto_scrypt-nosse.c
@@ -251,7 +251,7 @@ libscrypt_scrypt(const uint8_t * passwd, size_t passwdlen,
 		errno = EFBIG;
 		goto err0;
 	}
-	if (((N & (N - 1)) != 0) || (N == 0)) {
+	if (((N & (N - 1)) != 0) || (N < 2)) {
 		errno = EINVAL;
 		goto err0;
 	}


### PR DESCRIPTION
The parameter N must be a power of 2 greater than 1, but libscrypt_scrypt only checks that it's a power of 2 greater than 0. You get a segfault if you pass N=1 and a large enough r.
