### PR TITLE
r and p must be positive but not verified

### DIFF
--- a/crypto_scrypt-nosse.c
+++ b/crypto_scrypt-nosse.c
@@ -251,6 +251,10 @@ libscrypt_scrypt(const uint8_t * passwd, size_t passwdlen,
 		errno = EFBIG;
 		goto err0;
 	}
+	if (r == 0 || p == 0) {
+		errno = EINVAL;
+		goto err0;
+	}
 	if (((N & (N - 1)) != 0) || (N < 2)) {
 		errno = EINVAL;
 		goto err0;


### PR DESCRIPTION
SIGFPE with wrong parameters due to divide-by-zero. Can be caused with a valid-looking MCF.

These parameters are required to be positive by scrypt.pdf.
