### PR TITLE
Windows support added

### DIFF
--- a/crypto-mcf.c
+++ b/crypto-mcf.c
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <math.h>
 
-#ifndef S_SPLINT_S /* Including this here triggers a known bug in splint */
+#if !defined(S_SPLINT_S) && !defined(_WIN32) /* Including this here triggers a known bug in splint. Also, there is no such library on Windows */
 #include <unistd.h>
 #endif
 

--- a/crypto-scrypt-saltgen-windows.c
+++ b/crypto-scrypt-saltgen-windows.c
@@ -1,0 +1,22 @@
+#ifdef _WIN32 //_WIN32 defined on 64-bit Windows too
+#if _WIN32_WINNT < _WIN32_WINNT_WINXP
+#error Not supported Windows version. Windows XP or higher is required
+#endif
+#include <stdint.h>
+#include <windows.h>
+#include <wincrypt.h>
+#pragma comment(lib, "advapi32.lib")
+
+
+int libscrypt_salt_gen(uint8_t *salt, size_t len)
+{
+	HCRYPTPROV hCryptProv = 0;
+	BOOL returnCode;
+	if (!CryptAcquireContextW(&hCryptProv, 0, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
+		return -1;
+	returnCode = CryptGenRandom(hCryptProv, len, salt);
+	CryptReleaseContext(hCryptProv, 0);
+	return (returnCode == FALSE) ? -1 : 0;
+}
+
+#endif

--- a/crypto-scrypt-saltgen.c
+++ b/crypto-scrypt-saltgen.c
@@ -1,3 +1,4 @@
+#if !defined(_WIN32) && (defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))) //POSIX
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
@@ -46,3 +47,4 @@ int libscrypt_salt_gen(uint8_t *salt, size_t len)
 
 	return 0;
 }
+#endif

--- a/libscrypt.h
+++ b/libscrypt.h
@@ -33,8 +33,7 @@ int libscrypt_scrypt(const uint8_t *, size_t, const uint8_t *, size_t, uint64_t,
 int libscrypt_mcf(uint32_t N, uint32_t r, uint32_t p, const char *salt,
 	const char *hash, char *mcf);
 
-#ifndef _MSC_VER
-/* Generates a salt. Uses /dev/urandom/
+/* Generates a salt. Uses /dev/urandom/ on POSIX and CryptoAPI on Windows
  */
 int libscrypt_salt_gen(/*@out@*/ uint8_t *rand, size_t len);
 
@@ -42,7 +41,6 @@ int libscrypt_salt_gen(/*@out@*/ uint8_t *rand, size_t len);
 /* Returns >0 on success, or 0 for fail */
 int libscrypt_hash(char *dst, const char* passphrase, uint32_t N, uint8_t r,
   uint8_t p);
-#endif
 
 /* Checks a given MCF against a password */
 int libscrypt_check(char *mcf, const char *password);


### PR DESCRIPTION
Full Windows support
libscrypt_salt_gen and libscrypt_hash now works properly
Salt generation uses CryptoAPI on Windows
All tests passed on Windows and Linux
