### PR TITLE
Change type of N param from uint64_t to size_t

### DIFF
--- a/crypto_scrypt-nosse.c
+++ b/crypto_scrypt-nosse.c
@@ -232,7 +232,7 @@ smix(uint8_t * B, size_t r, uint64_t N, uint32_t * V, uint32_t * XY)
  */
 int
 libscrypt_scrypt(const uint8_t * passwd, size_t passwdlen,
-    const uint8_t * salt, size_t saltlen, uint64_t N, uint32_t r, uint32_t p,
+    const uint8_t * salt, size_t saltlen, size_t N, uint32_t r, uint32_t p,
     uint8_t * buf, size_t buflen)
 {
 	void * B0, * V0, * XY0;

--- a/libscrypt.h
+++ b/libscrypt.h
@@ -26,7 +26,7 @@ extern "C"{
  * standard unless you want to modify the CPU/RAM ratio.
  * Return 0 on success; or -1 on error.
  */
-int libscrypt_scrypt(const uint8_t *, size_t, const uint8_t *, size_t, uint64_t,
+int libscrypt_scrypt(const uint8_t *, size_t, const uint8_t *, size_t, size_t,
     uint32_t, uint32_t, /*@out@*/ uint8_t *, size_t);
 
 /* Converts a series of input parameters to a MCF form for storage */


### PR DESCRIPTION
There is check in crypto_scrypt-nosse.c:

```
if (N > SIZE_MAX / 128 / r)) {
  errno = ENOMEM;
  goto err0;
}
```

and SIZE_MAX defined as 0xffffffff, so there is no sense to use uint64_t type. 
