### PR TITLE
Disable the use of internal b64.c and sha256.c if using PolarSSL and more Windows support

### DIFF
--- a/crypto-mcf.c
+++ b/crypto-mcf.c
@@ -6,8 +6,10 @@
 #include <stdint.h>
 #include <math.h>
 
-#ifndef S_SPLINT_S /* Including this here triggers a known bug in splint */
-#include <unistd.h>
+#ifndef _WIN32
+#  ifndef S_SPLINT_S /* Including this here triggers a known bug in splint */
+#    include <unistd.h>
+#  endif
 #endif
 
 #include "libscrypt.h"

--- a/crypto-scrypt-saltgen.c
+++ b/crypto-scrypt-saltgen.c
@@ -4,14 +4,33 @@
 #include <errno.h>
 #include <fcntl.h>
 
-#ifndef S_SPLINT_S /* Including this here triggers a known bug in splint */
-#include <unistd.h>
-#endif
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  ifndef S_SPLINT_S /* Including this here triggers a known bug in splint */
+#    include <unistd.h>
+#  endif
 
-#define RNGDEV "/dev/urandom"
+#  define RNGDEV "/dev/urandom"
+#endif
 
 int libscrypt_salt_gen(uint8_t *salt, size_t len)
 {
+#ifdef _WIN32
+	HCRYPTPROV hCryptProv = 0;
+	int ret = 0;
+
+	if (!CryptAcquireContext(&hCryptProv, 0, 0, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+		return -1;
+
+	if (!CryptGenRandom(hCryptProv, (DWORD)len, salt))
+		ret = -1;
+
+	if (!CryptReleaseContext(hCryptProv, 0))
+		ret = -1;
+
+	return ret;
+#else
 	unsigned char buf[len];
 	size_t data_read = 0;
 	int urandom = open(RNGDEV, O_RDONLY);
@@ -45,4 +64,5 @@ int libscrypt_salt_gen(uint8_t *salt, size_t len)
 	memcpy(salt, buf, len);
 
 	return 0;
+#endif
 }

--- a/crypto_scrypt-check.c
+++ b/crypto_scrypt-check.c
@@ -3,7 +3,11 @@
 #include <stdio.h>
 #include <math.h>
 
-#include "b64.h"
+#ifdef WITH_POLARSSL
+#  include "polarssl/base64.h"
+#else
+#  include "b64.h"
+#endif
 #include "slowequals.h"
 #include "libscrypt.h"
 
@@ -32,6 +36,9 @@ int libscrypt_check(char *mcf, const char *password)
 	char outbuf[128];
 	uint8_t salt[32];
 	char *tok;
+#ifdef WITH_POLARSSL
+	size_t dlen;
+#endif
 
 	if(memcmp(mcf, SCRYPT_MCF_ID, 3) != 0)
 	{
@@ -71,9 +78,18 @@ int libscrypt_check(char *mcf, const char *password)
 	*/
 
 	memset(salt, 0, sizeof(salt)); /* Keeps splint happy */
+#ifdef WITH_POLARSSL
+	dlen = sizeof(salt);
+	retval = base64_decode(salt, &dlen, (unsigned char*)tok, strlen(tok));
+	if (retval != 0)
+		return -1;
+	else
+		retval = dlen;
+#else
 	retval = libscrypt_b64_decode(tok, (unsigned char*)salt, sizeof(salt));
 	if (retval < 1)
 		return -1;
+#endif
 
 	retval = libscrypt_scrypt((uint8_t*)password, strlen(password), salt,
             (uint32_t)retval, N, r, p, hashbuf, sizeof(hashbuf));
@@ -81,8 +97,17 @@ int libscrypt_check(char *mcf, const char *password)
 	if (retval != 0)
 		return -1;
 
+#ifdef WITH_POLARSSL
+	dlen = sizeof(outbuf);
+	retval = base64_encode((unsigned char*)outbuf, &dlen, hashbuf, sizeof(hashbuf));
+	if(retval == 0)
+		retval = 1;
+	else
+		retval = 0;
+#else
 	retval = libscrypt_b64_encode((unsigned char*)hashbuf, sizeof(hashbuf), 
             outbuf, sizeof(outbuf));
+#endif
 
 	if (retval == 0)
 		return -1;

--- a/crypto_scrypt-hash.c
+++ b/crypto_scrypt-hash.c
@@ -3,7 +3,11 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#include "b64.h"
+#ifdef WITH_POLARSSL
+#  include "polarssl/base64.h"
+#else
+#  include "b64.h"
+#endif
 #include "libscrypt.h"
 
 int libscrypt_hash(char *dst, const char *passphrase, uint32_t N, uint8_t r,
@@ -15,6 +19,9 @@ int libscrypt_hash(char *dst, const char *passphrase, uint32_t N, uint8_t r,
 	uint8_t	hashbuf[SCRYPT_HASH_LEN];
 	char outbuf[256];
 	char saltbuf[256];
+#ifdef WITH_POLARSSL
+	size_t dlen;
+#endif
 
 	if(libscrypt_salt_gen(salt, SCRYPT_SALT_LEN) == -1)
 	{
@@ -26,6 +33,17 @@ int libscrypt_hash(char *dst, const char *passphrase, uint32_t N, uint8_t r,
 	if(retval == -1)
 		return 0;
 
+#ifdef WITH_POLARSSL
+	dlen = sizeof(outbuf);
+	retval = base64_encode((unsigned char*)outbuf, &dlen, hashbuf, sizeof(hashbuf));
+	if(retval != 0)
+		return 0;
+
+	dlen = sizeof(saltbuf);
+	retval = base64_encode((unsigned char*)saltbuf, &dlen, salt, sizeof(salt));
+	if(retval != 0)
+		return 0;
+#else
 	retval = libscrypt_b64_encode((unsigned char*)hashbuf, sizeof(hashbuf),
 			outbuf, sizeof(outbuf));
 	if(retval == -1)
@@ -35,6 +53,7 @@ int libscrypt_hash(char *dst, const char *passphrase, uint32_t N, uint8_t r,
 			saltbuf, sizeof(saltbuf));
 	if(retval == -1)
 		return 0;
+#endif
 
 	retval = libscrypt_mcf(N, r, p, saltbuf, outbuf, dst);
 	if(retval != 1)

--- a/libscrypt.h
+++ b/libscrypt.h
@@ -33,7 +33,6 @@ int libscrypt_scrypt(const uint8_t *, size_t, const uint8_t *, size_t, uint64_t,
 int libscrypt_mcf(uint32_t N, uint32_t r, uint32_t p, const char *salt,
 	const char *hash, char *mcf);
 
-#ifndef _MSC_VER
 /* Generates a salt. Uses /dev/urandom/ or CryptGenRandom(for windows)
  */
 int libscrypt_salt_gen(/*@out@*/ uint8_t *rand, size_t len);
@@ -42,7 +41,6 @@ int libscrypt_salt_gen(/*@out@*/ uint8_t *rand, size_t len);
 /* Returns >0 on success, or 0 for fail */
 int libscrypt_hash(char *dst, const char* passphrase, uint32_t N, uint8_t r,
   uint8_t p);
-#endif
 
 /* Checks a given MCF against a password */
 int libscrypt_check(char *mcf, const char *password);

--- a/libscrypt.h
+++ b/libscrypt.h
@@ -34,7 +34,7 @@ int libscrypt_mcf(uint32_t N, uint32_t r, uint32_t p, const char *salt,
 	const char *hash, char *mcf);
 
 #ifndef _MSC_VER
-/* Generates a salt. Uses /dev/urandom/
+/* Generates a salt. Uses /dev/urandom/ or CryptGenRandom(for windows)
  */
 int libscrypt_salt_gen(/*@out@*/ uint8_t *rand, size_t len);
 


### PR DESCRIPTION
Because I'm using PolarSSL in my project, I prefer to disable the b64.c and sha256.c files and use the PolarSSL's.

I also found some changes from Convey-Compliance/libscrypt, with better Windows support: possibility to generate salt from libscrypt (Windows APi used).

If you define WITH_POLARSSL during preprocessor (-DWITH_POLARSSL) with gcc, no need to use b64.c and sha256.c to build, but you need to specify "-lpolarssl" during link.