### PR TITLE
SHA256: Remove dead store

### DIFF
--- a/sha256.c
+++ b/sha256.c
@@ -173,11 +173,6 @@ SHA256_Transform(uint32_t * state, const unsigned char block[64])
 	/* 4. Mix local working variables into global state */
 	for (i = 0; i < 8; i++)
 		state[i] += S[i];
-
-	/* Clean the stack. */
-	memset(W, 0, 256);
-	memset(S, 0, 32);
-	t0 = t1 = 0;
 }
 
 static unsigned char PAD[64] = {


### PR DESCRIPTION
The main reason for this is that clang static analyzer is complaining about `t0 = t1 = 0`.

But I'm quite confident that compilers will remove also memsets. Even if not now, they can remove them in future.

If that is needed for security reasons, something like memset_s must be used.
If you want something faster, I can copy SHA256 from secp256k1: https://github.com/bitcoin-core/secp256k1/blob/master/src/hash_impl.h. 