### PR TITLE
Add meson build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 reference
 endian.h
 byteorder
+build/

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,23 @@
+project('libscrypt', 'c', version : '0.1.21')
+
+version = meson.project_version()
+
+sources = ['crypto_scrypt-check.c',
+'crypto_scrypt-hash.c',
+'crypto_scrypt-hexconvert.c',
+'crypto_scrypt-nosse.c',
+'crypto-mcf.c',
+'crypto-scrypt-saltgen.c',
+'slowequals.c',
+'sha256.c',
+'b64.c'
+]
+inc = include_directories('./')
+install_headers('libscrypt.h','sha256.h',subdir: 'libscrypt')
+lib = library('libscrypt', sources: sources, version: version,
+include_directories : inc,
+c_args: ['-Wall', '-O2', '-ffast-math', '-g', '-D_FORTIFY_SOURCE=2', '-fstack-protector'],
+install: true)
+
+urbit_scrypt_dep = declare_dependency(include_directories : inc,
+  link_with : lib)

--- a/meson.build
+++ b/meson.build
@@ -19,5 +19,5 @@ include_directories : inc,
 c_args: ['-Wall', '-O2', '-ffast-math', '-g', '-D_FORTIFY_SOURCE=2', '-fstack-protector'],
 install: true)
 
-urbit_scrypt_dep = declare_dependency(include_directories : inc,
+libscrypt_dep = declare_dependency(include_directories : inc,
   link_with : lib)


### PR DESCRIPTION
Meson is a great replacement for more fancy than Makefile build system. It is pretty non-invasive 
and would be  cool to have this in libscrypt. 

