### PR TITLE
Fix C++14 build error in Visual Studio 2019 on Windows

### DIFF
--- a/main.c
+++ b/main.c
@@ -53,7 +53,10 @@ int main()
 		printf("TEST ONE FAILED: Failed to detect invalid input\n");
 		exit(EXIT_FAILURE);
 	}
-	printf("TEST ONE and a half: Successfully failed on error: %s\n", strerror(errno));
+	
+	char errormsg[64];
+	strerror_s(errormsg, 64, errno);
+	printf("TEST ONE and a half: Successfully failed on error: %s\n", errormsg);
 
 	/* Convert the binary string to hex representation. Outbuf must be
 	* at least sizeof(hashbuf) * 2 + 1


### PR DESCRIPTION
I get the following build error when building in Visual Studio 2019 on Windows (with the C++ standard set to C++14):

`warning C4996: 'str error ': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS.`

These changes fix the build error by replacing `strerror ` with `strerror_s `. 