### PR TITLE
sysendian.h: fix aliasing violations

### DIFF
--- a/b64.c
+++ b/b64.c
@@ -120,11 +120,7 @@ static const char Pad64 = '=';
 */
 
 int
-libscrypt_b64_encode(src, srclength, target, targsize)
-	unsigned char const *src;
-	size_t srclength;
-	char *target;
-	size_t targsize;
+libscrypt_b64_encode(unsigned char const *src, size_t srclength, char *target, size_t targsize)
 {
 	size_t datalength = 0;
 	unsigned char input[3];
@@ -184,10 +180,7 @@ libscrypt_b64_encode(src, srclength, target, targsize)
  */
 
 int
-libscrypt_b64_decode(src, target, targsize)
-	char const *src;
-	unsigned char *target;
-	size_t targsize;
+libscrypt_b64_decode(char const *src, unsigned char *target, size_t targsize)
 {
 	int state, ch;
     unsigned int tarindex;

--- a/sysendian.h
+++ b/sysendian.h
@@ -49,95 +49,77 @@
 #endif
 
 static INLINE uint32_t
-be32dec(const void *pp)
+be32dec(const unsigned char* p)
 {
-	const uint8_t *p = (uint8_t const *)pp;
-
-	return ((uint32_t)(p[3]) + ((uint32_t)(p[2]) << 8) +
-	    ((uint32_t)(p[1]) << 16) + ((uint32_t)(p[0]) << 24));
+	return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) |
+		((uint32_t)p[3] << 0);
 }
 
 static INLINE void
-be32enc(void *pp, uint32_t x)
+be32enc(unsigned char* p, const uint32_t x)
 {
-	uint8_t * p = (uint8_t *)pp;
-
-	p[3] = x & 0xff;
-	p[2] = (x >> 8) & 0xff;
-	p[1] = (x >> 16) & 0xff;
-	p[0] = (x >> 24) & 0xff;
+	p[0] = (x >> 24);
+	p[1] = (x >> 16);
+	p[2] = (x >> 8);
+	p[3] = (x >> 0);
 }
 
 static INLINE uint64_t
-be64dec(const void *pp)
+be64dec(const unsigned char* p)
 {
-	const uint8_t *p = (uint8_t const *)pp;
-
-	return ((uint64_t)(p[7]) + ((uint64_t)(p[6]) << 8) +
-	    ((uint64_t)(p[5]) << 16) + ((uint64_t)(p[4]) << 24) +
-	    ((uint64_t)(p[3]) << 32) + ((uint64_t)(p[2]) << 40) +
-	    ((uint64_t)(p[1]) << 48) + ((uint64_t)(p[0]) << 56));
+	return ((uint64_t)p[0] << 0) | ((uint64_t)p[1] << 8) | ((uint64_t)p[2] << 16) |
+		((uint64_t)p[3] << 24) | ((uint64_t)p[4] << 32) | ((uint64_t)p[5] << 40) |
+		((uint64_t)p[6] << 48) | ((uint64_t)p[7] << 56);
 }
 
 static INLINE void
-be64enc(void *pp, uint64_t x)
+be64enc(unsigned char* p, const uint64_t x)
 {
-	uint8_t * p = (uint8_t *)pp;
-
-	p[7] = x & 0xff;
-	p[6] = (x >> 8) & 0xff;
-	p[5] = (x >> 16) & 0xff;
-	p[4] = (x >> 24) & 0xff;
-	p[3] = (x >> 32) & 0xff;
-	p[2] = (x >> 40) & 0xff;
-	p[1] = (x >> 48) & 0xff;
-	p[0] = (x >> 56) & 0xff;
+	p[0] = (x >> 56);
+	p[1] = (x >> 48);
+	p[2] = (x >> 40);
+	p[3] = (x >> 32);
+	p[4] = (x >> 24);
+	p[5] = (x >> 16);
+	p[6] = (x >> 8);
+	p[7] = (x >> 0);
 }
 
 static INLINE uint32_t
-le32dec(const void *pp)
+le32dec(const unsigned char* p)
 {
-	const uint8_t *p = (uint8_t const *)pp;
-
-	return ((uint32_t)(p[0]) + ((uint32_t)(p[1]) << 8) +
-	    ((uint32_t)(p[2]) << 16) + ((uint32_t)(p[3]) << 24));
+	return ((uint32_t)p[0] << 0) | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) |
+		((uint32_t)p[3] << 24);
 }
 
 static INLINE void
-le32enc(void *pp, uint32_t x)
+le32enc(unsigned char* p, const uint32_t x)
 {
-	uint8_t * p = (uint8_t *)pp;
-
-	p[0] = x & 0xff;
-	p[1] = (x >> 8) & 0xff;
-	p[2] = (x >> 16) & 0xff;
-	p[3] = (x >> 24) & 0xff;
+	p[0] = (x >> 0);
+	p[1] = (x >> 8);
+	p[2] = (x >> 16);
+	p[3] = (x >> 24);
 }
 
 static INLINE uint64_t
-le64dec(const void *pp)
+le64dec(const unsigned char* p)
 {
-	const uint8_t *p = (uint8_t const *)pp;
-
-	return ((uint64_t)(p[0]) + ((uint64_t)(p[1]) << 8) +
-	    ((uint64_t)(p[2]) << 16) + ((uint64_t)(p[3]) << 24) +
-	    ((uint64_t)(p[4]) << 32) + ((uint64_t)(p[5]) << 40) +
-	    ((uint64_t)(p[6]) << 48) + ((uint64_t)(p[7]) << 56));
+	return ((uint64_t)p[0] << 0) | ((uint64_t)p[1] << 8) | ((uint64_t)p[2] << 16) |
+		((uint64_t)p[3] << 24) | ((uint64_t)p[4] << 32) | ((uint64_t)p[5] << 40) |
+		((uint64_t)p[6] << 48) | ((uint64_t)p[7] << 56);
 }
 
 static INLINE void
-le64enc(void *pp, uint64_t x)
+le64enc(unsigned char* p, const uint64_t x)
 {
-	uint8_t * p = (uint8_t *)pp;
-
-	p[0] = x & 0xff;
-	p[1] = (x >> 8) & 0xff;
-	p[2] = (x >> 16) & 0xff;
-	p[3] = (x >> 24) & 0xff;
-	p[4] = (x >> 32) & 0xff;
-	p[5] = (x >> 40) & 0xff;
-	p[6] = (x >> 48) & 0xff;
-	p[7] = (x >> 56) & 0xff;
+	p[0] = (x >> 0);
+	p[1] = (x >> 8);
+	p[2] = (x >> 16);
+	p[3] = (x >> 24);
+	p[4] = (x >> 32);
+	p[5] = (x >> 40);
+	p[6] = (x >> 48);
+	p[7] = (x >> 56);
 }
 #endif /* !HAVE_SYS_ENDIAN_H */
 


### PR DESCRIPTION
Accessing a e.g. uint32_t as uint8_t is an aliasing violation. The
helpers here are nearly idiomatic for avoiding that anyway, so fix
them up accordingly.